### PR TITLE
Directly access gs or fs segment for PEB

### DIFF
--- a/asm/main32.asm
+++ b/asm/main32.asm
@@ -5,12 +5,11 @@ SECTION .text align=16
 align 16
 WinMainCRTStartup:
 		sub		esp, 20h
-		mov		eax, [fs:18h]				; Get TEB
 
 		push	ebx
 		push	ebp
 		push	esi
-		mov		eax, [eax+30h]				; Get PEB and traverse to Peb->Ldr->InLoadOrderModuleList.Flink->Flink
+		mov		eax, [fs:30h]				; Get PEB and traverse to Peb->Ldr->InLoadOrderModuleList.Flink->Flink
 		mov		esi, 20Bh
 		push	edi
 		push	78h

--- a/asm/main64.asm
+++ b/asm/main64.asm
@@ -14,9 +14,8 @@ WinMainCRTStartup:
 		push	r14
 		sub		rsp, 40h
 
-		mov		rax, [gs:30h]			; Get TEB
 		mov		edx, 20Bh
-		mov		rcx, [rax+60h]			; Get PEB and traverse to Peb->Ldr->InLoadOrderModuleList.Flink->Flink
+		mov		rcx, [gs:60h]			; Get PEB and traverse to Peb->Ldr->InLoadOrderModuleList.Flink->Flink
 		mov		rax, [rcx+18h]
 		mov		rcx, [rax+10h]
 		mov		rax, [rcx]


### PR DESCRIPTION
Instead of
```asm
mov rax, gs:[30h]
mov rax, [rax + 60h]
```

We can just `mov rax, gs:[60h]` directly.

[Why load fs:[0x18] into a register and then dereference that, instead of just going for fs:[n] directly?](https://devblogs.microsoft.com/oldnewthing/20220919-00/?p=107195)